### PR TITLE
update user-facing SAML title

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -38,7 +38,7 @@ SSO_SAML_IDPS = {
     'caltechdata_sso': {
 
         # Basic info
-        "title": "SAML",
+        "title": "access.caltech",
         "description": "SAML Authentication Service",
         "icon": "",
 


### PR DESCRIPTION
appears on "Sign in with …" button; would probably better saying "Sign in with access.caltech"

![image](https://user-images.githubusercontent.com/415179/185722527-278b2d41-c9f3-40a1-91a9-167c69199b9c.png)
